### PR TITLE
Bug fix for :use-only

### DIFF
--- a/src/defpackage-plus.lisp
+++ b/src/defpackage-plus.lisp
@@ -19,7 +19,7 @@ defpackage-plus; user methods should **not** specialize on these."))
   (use-package params package))
 
 (defmethod defpackage+-dispatch ((option (eql :use-only)) params package)
-  (ensure-use-only package params))
+  (ensure-use-only params package))
 
 (defmethod defpackage+-dispatch ((option (eql :export)) params package)
   (ensure-export params package))


### PR DESCRIPTION
The arguments to `ensure-use-only` in `defpackage+-dispatch` were transposed, so `:use-only` didn't work.
