### PR TITLE
Add support for local-nicknames

### DIFF
--- a/defpackage-plus.asd
+++ b/defpackage-plus.asd
@@ -19,5 +19,6 @@
    (:file "utility")
    (:file "ensure")
    (:file "inherit")
+   (:file "local-nicknames")
    (:file "defpackage-plus")
    (:file "package-plus")))

--- a/src/local-nicknames.lisp
+++ b/src/local-nicknames.lisp
@@ -1,0 +1,21 @@
+(in-package :defpackage-plus-1)
+
+(defun ensure-global-nickname (package nickname)
+  (let ((package (find-package package)))
+    (rename-package package (package-name package)
+                    (adjoin nickname (package-nicknames package)))))
+
+(defun add-local-nickname (package nickname local-to)
+  (declare (ignorable package nickname local-to))
+  #+package-local-nicknames
+  #+sbcl
+  (sb-ext:add-package-local-nickname nickname package local-to)
+  #+(or abcl ecl)
+  (ext:add-package-local-nickname nickname package local-to))
+
+(defmethod defpackage+-dispatch ((option (eql :local-nicknames)) params package)
+  (loop :for (nick pack) :in params :do
+    (ensure-package pack)
+    (add-local-nickname pack nick package)
+        #-package-local-nicknames (ensure-global-nickname pack nick)))
+

--- a/src/local-nicknames.lisp
+++ b/src/local-nicknames.lisp
@@ -9,10 +9,11 @@
 (defun add-local-nickname (package nickname local-to)
   (declare (ignorable package nickname local-to))
   #+package-local-nicknames
-  #+sbcl
-  (sb-ext:add-package-local-nickname nickname package local-to)
-  #+(or abcl ecl)
-  (ext:add-package-local-nickname nickname package local-to))
+  (progn
+    #+sbcl
+    (sb-ext:add-package-local-nickname nickname package local-to)
+    #+(or abcl ecl)
+    (ext:add-package-local-nickname nickname package local-to)))
 
 (defmethod defpackage+-dispatch ((option (eql :local-nicknames)) params package)
   (loop :for (nick pack) :in params :do

--- a/src/local-nicknames.lisp
+++ b/src/local-nicknames.lisp
@@ -8,16 +8,17 @@
 
 (defun add-local-nickname (package nickname local-to)
   (declare (ignorable package nickname local-to))
-  #+package-local-nicknames
-  (progn
-    #+sbcl
-    (sb-ext:add-package-local-nickname nickname package local-to)
-    #+(or abcl ecl)
-    (ext:add-package-local-nickname nickname package local-to)))
+  #+sbcl
+  (sb-ext:add-package-local-nickname nickname package local-to)
+  #+(or abcl ecl)
+  (ext:add-package-local-nickname nickname package local-to))
 
 (defmethod defpackage+-dispatch ((option (eql :local-nicknames)) params package)
   (loop :for (nick pack) :in params :do
-    (ensure-package pack)
-    (add-local-nickname pack nick package
-        #-package-local-nicknames (ensure-global-nickname pack nick))))
+    (progn
+      (ensure-package pack)
+      #+package-local-nicknames
+      (add-local-nickname pack nick package)
+      #-package-local-nicknames
+      (ensure-global-nickname pack nick))))
 

--- a/src/local-nicknames.lisp
+++ b/src/local-nicknames.lisp
@@ -3,7 +3,8 @@
 (defun ensure-global-nickname (package nickname)
   (let ((package (find-package package)))
     (rename-package package (package-name package)
-                    (adjoin nickname (package-nicknames package)))))
+                    (adjoin nickname (package-nicknames package)
+                            :key #'string :test #'equal))))
 
 (defun add-local-nickname (package nickname local-to)
   (declare (ignorable package nickname local-to))
@@ -16,6 +17,6 @@
 (defmethod defpackage+-dispatch ((option (eql :local-nicknames)) params package)
   (loop :for (nick pack) :in params :do
     (ensure-package pack)
-    (add-local-nickname pack nick package)
-        #-package-local-nicknames (ensure-global-nickname pack nick)))
+    (add-local-nickname pack nick package
+        #-package-local-nicknames (ensure-global-nickname pack nick))))
 


### PR DESCRIPTION
This adds a `:local-nicknames` keyword to defpackage+ which properly uses local nicknames on implementations that support it and adds a global nickname on implementations which don't. The idea is to provide an alternative for packages that wish to use short global nicknames- instead they add local nicknames in the places they'd use the shorter global one, and on implementations which actually support local nicknames they won't be clashing with other similar packages. Unsupported implementations would still clash, but at least this is no worse than if a global nickname was used. This provides a transition option while local package nicknames are still being adopted by the various CL impls.