### PR TITLE
Fix conditionalization for old versions of supporting impls

### DIFF
--- a/src/local-nicknames.lisp
+++ b/src/local-nicknames.lisp
@@ -8,10 +8,12 @@
 
 (defun add-local-nickname (package nickname local-to)
   (declare (ignorable package nickname local-to))
-  #+sbcl
-  (sb-ext:add-package-local-nickname nickname package local-to)
-  #+(or abcl ecl)
-  (ext:add-package-local-nickname nickname package local-to))
+  #+package-local-nicknames
+  (progn
+    #+sbcl
+    (sb-ext:add-package-local-nickname nickname package local-to)
+    #+(or abcl ecl)
+    (ext:add-package-local-nickname nickname package local-to)))
 
 (defmethod defpackage+-dispatch ((option (eql :local-nicknames)) params package)
   (loop :for (nick pack) :in params :do


### PR DESCRIPTION
This is the fix for the minor bug @mfiano mentioned on #2- in short, since many versions of ECL don't actually support local nicknames yet, they would fail to compile the `add-local-nickname` function. Just needed to move a reader conditional.